### PR TITLE
refactor: add test utilities

### DIFF
--- a/test/mocks/carbonio-shell-ui-constants.ts
+++ b/test/mocks/carbonio-shell-ui-constants.ts
@@ -35,3 +35,11 @@ export const ZIMBRA_STANDARD_COLORS = [
 	{ zValue: 8, hex: '#828282', zLabel: 'gray' },
 	{ zValue: 9, hex: '#ba8b00', zLabel: 'orange' }
 ];
+
+export enum JSNS {
+	ACCOUNT = 'urn:zimbraAccount',
+	ADMIN = 'urn:zimbraAdmin',
+	MAIL = 'urn:zimbraMail',
+	ALL = 'urn:zimbra',
+	SYNC = 'urn:zimbraSync'
+}

--- a/test/mocks/carbonio-shell-ui.tsx
+++ b/test/mocks/carbonio-shell-ui.tsx
@@ -15,7 +15,7 @@ import { getSoapFetch } from './network/fetch';
 import { generateSettings } from './settings/settings-generator';
 import { tags } from './tags/tags';
 
-export { FOLDERS, ZIMBRA_STANDARD_COLORS } from './carbonio-shell-ui-constants';
+export { FOLDERS, ZIMBRA_STANDARD_COLORS, JSNS } from './carbonio-shell-ui-constants';
 
 const FakeIntegration = (): React.JSX.Element => <div data-testid="fake-component" />;
 

--- a/test/mocks/utils/soap.ts
+++ b/test/mocks/utils/soap.ts
@@ -1,0 +1,13 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { SuccessSoapResponse } from '@zextras/carbonio-shell-ui';
+
+export const buildSoapResponse = <T>(responseData: Record<string, T>): SuccessSoapResponse<T> => ({
+	Header: {
+		context: {}
+	},
+	Body: responseData
+});


### PR DESCRIPTION
- Add a mock for the JSNS constant provided by Shell
- Add the `buildSoapResponse` utility function to compose the mocked SOAP response