### PR TITLE
fix: restore getBridgedFunctions mock

### DIFF
--- a/test/mocks/carbonio-shell-ui.tsx
+++ b/test/mocks/carbonio-shell-ui.tsx
@@ -40,6 +40,7 @@ export const pushHistory = jest.fn();
 export const useBoard = jest.fn();
 
 export const useAppContext = jest.fn<unknown, []>(() => mockedAccounts);
+export const getBridgedFunctions = jest.fn();
 export const addBoard = jest.fn();
 export const useBoardHooks = jest.fn();
 export const minimizeBoards = jest.fn();


### PR DESCRIPTION
Restore the getBridgedFunctions function mock to avoid failing tests until [#509](https://github.com/zextras/carbonio-mails-ui/pull/509) will not be merged