### PR TITLE
feat: add email parser helpers

### DIFF
--- a/helpers/email-parser.ts
+++ b/helpers/email-parser.ts
@@ -1,0 +1,26 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+/*
+ * SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export function parseEmail(input: string): string | undefined {
+	const extracted = extractEmail(input);
+	return isValidEmail(extracted) ? extracted : undefined;
+}
+
+export function isValidEmail(email: string | undefined): boolean {
+	// eslint-disable-next-line max-len, prettier/prettier, no-useless-escape
+	const validEmailRegex = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+	return validEmailRegex.test(String(email).toLowerCase());
+}
+
+function extractEmail(input: string): string {
+	const trimmedInput = input.trim();
+	const caputured = /.*<(.*)>/.exec(trimmedInput);
+	if (caputured && caputured.length > 1) {
+		return caputured[1].trim();
+	}
+	return trimmedInput;
+}

--- a/helpers/tests/email-parser.test.ts
+++ b/helpers/tests/email-parser.test.ts
@@ -1,0 +1,65 @@
+/* eslint-disable sonarjs/no-duplicate-string */
+import { isValidEmail, parseEmail } from '../email-parser';
+
+/*
+ * SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+describe('email-parser', () => {
+	describe('isValidEmail', () => {
+		it('undefined is not valid', () => {
+			expect(isValidEmail(undefined)).toBe(false);
+		});
+		it('empty email is not valid', () => {
+			expect(isValidEmail('')).toBe(false);
+		});
+
+		it('simple text is not valid', () => {
+			expect(isValidEmail('invalid')).toBe(false);
+		});
+
+		it('email with invalid domain is not valid', () => {
+			expect(isValidEmail('other@invalid')).toBe(false);
+		});
+
+		it('email with special character is not valid', () => {
+			expect(isValidEmail('other@inv?al.id')).toBe(false);
+		});
+
+		it('email with invalid format is not valid', () => {
+			expect(isValidEmail('@invalid.it')).toBe(false);
+		});
+
+		it('valid email is valid', () => {
+			expect(isValidEmail('e@mail.it')).toBe(true);
+		});
+	});
+
+	describe('parseEmail', () => {
+		it('cannot parse empty string', () => {
+			expect(parseEmail('')).toStrictEqual(undefined);
+		});
+		it('clean Email in extended format with name', () => {
+			expect(parseEmail('"Name" <email@domain.it>')).toBe('email@domain.it');
+		});
+		it('clean Email already ok', () => {
+			expect(parseEmail('another@domain.it')).toBe('another@domain.it');
+		});
+		it('clean Email surrounded with <>', () => {
+			expect(parseEmail('<other@domain.it>')).toBe('other@domain.it');
+		});
+		it('clean Email trimming spaces', () => {
+			expect(parseEmail(' a@domain.it ')).toBe('a@domain.it');
+		});
+		it('email to trim in extended format', () => {
+			expect(parseEmail('"Name" < email@domain.it >')).toBe('email@domain.it');
+		});
+		it('do not parse invalid email in extended format', () => {
+			expect(parseEmail('"Name" <invalid@email>')).toBe(undefined);
+		});
+		it('do not parse an invalid email', () => {
+			expect(parseEmail('invalidEmail ')).toBe(undefined);
+		});
+	});
+});


### PR DESCRIPTION
REF: CO-1148 
Add email parser helpers:
  - parseEmail(input: string): string | undefined
  - isValidEmail(email: string | undefined): boolean