### PR TITLE
test: add id param to useIntegratedComponent shell mock ref: WSC-1715

### DIFF
--- a/test/mocks/carbonio-shell-ui.tsx
+++ b/test/mocks/carbonio-shell-ui.tsx
@@ -136,8 +136,14 @@ export const useReplaceHistoryCallback = useReplaceHistoryMock;
 const FakeIntegrationComponent = (): React.JSX.Element => <div data-testid="fake-component" />;
 const IntegrationComponent = jest.fn(FakeIntegrationComponent);
 const isIntegrationAvailable = false;
-export const useIntegratedComponent = jest.fn(() => [IntegrationComponent, isIntegrationAvailable]);
-export const getIntegratedComponent = jest.fn(() => [IntegrationComponent, isIntegrationAvailable]);
+export const useIntegratedComponent = jest.fn((id: string) => [
+	IntegrationComponent,
+	isIntegrationAvailable
+]);
+export const getIntegratedComponent = jest.fn((id: string) => [
+	IntegrationComponent,
+	isIntegrationAvailable
+]);
 
 // Integrated actions
 export const getAction = jest.fn<


### PR DESCRIPTION
I updated the mocks for `useIntegratedComponent` and `getIntegratedComponent` by adding the `id` parameter to match the expected type definitions.
This adjustment was necessary to ensure compatibility with `.mockImplementation` in the tests (https://github.com/zextras/carbonio-calendars-ui/pull/507#pullrequestreview-2407547166), allowing the mocks to correctly align with the component’s function signature and avoid type errors.