### PR TITLE
refactor: react router dom migration

### DIFF
--- a/helpers/folders.ts
+++ b/helpers/folders.ts
@@ -27,7 +27,7 @@ type FolderIdType = { zid: string | null; id: string | null };
  * Parse the given folder id and returns on object with the composing parts of the folder id
  * @param folderId
  */
-export const getFolderIdParts = (folderId?: string): FolderIdType => {
+export const getFolderIdParts = (folderId: string): FolderIdType => {
 	const result: FolderIdType = { zid: null, id: null };
 
 	if (!folderId || !folderId.match(FOLDERID_REGEX)) {

--- a/helpers/folders.ts
+++ b/helpers/folders.ts
@@ -27,7 +27,7 @@ type FolderIdType = { zid: string | null; id: string | null };
  * Parse the given folder id and returns on object with the composing parts of the folder id
  * @param folderId
  */
-export const getFolderIdParts = (folderId: string): FolderIdType => {
+export const getFolderIdParts = (folderId?: string): FolderIdType => {
 	const result: FolderIdType = { zid: null, id: null };
 
 	if (!folderId || !folderId.match(FOLDERID_REGEX)) {

--- a/helpers/use-history-navigation.test.ts
+++ b/helpers/use-history-navigation.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { useHistoryNavigation } from './use-history-navigation';
+import { setupHook } from '../test/test-setup';
+
+describe('useHistoryNavigation', () => {
+	it('should return an object with two functions', () => {
+		const {
+			result: { current: navigation }
+		} = setupHook(useHistoryNavigation);
+
+		expect(navigation).toEqual({
+			replaceHistory: expect.any(Function),
+			pushHistory: expect.any(Function)
+		});
+	});
+});

--- a/helpers/use-history-navigation.ts
+++ b/helpers/use-history-navigation.ts
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { useCallback, useMemo } from 'react';
+
+import { useNavigate } from 'react-router-dom';
+
+export type HistoryNavigation = {
+	replaceHistory: (path: string) => void;
+	pushHistory: (path: string) => void;
+};
+
+export const useHistoryNavigation = (): HistoryNavigation => {
+	const navigate = useNavigate();
+
+	const replaceHistory = useCallback(
+		(path: string): void => {
+			navigate(path, { replace: true });
+		},
+		[navigate]
+	);
+
+	const pushHistory = useCallback(
+		(path: string): void => {
+			navigate(path, { replace: false });
+		},
+		[navigate]
+	);
+
+	return useMemo<HistoryNavigation>(
+		() => ({
+			replaceHistory,
+			pushHistory
+		}),
+		[replaceHistory, pushHistory]
+	);
+};

--- a/test/mocks/carbonio-shell-ui.tsx
+++ b/test/mocks/carbonio-shell-ui.tsx
@@ -4,12 +4,10 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import React, { FC, ReactNode, useCallback } from 'react';
+import React, { FC, ReactNode } from 'react';
 
 import * as shell from '@zextras/carbonio-shell-ui';
 import { useActions as realUseActions } from '@zextras/carbonio-shell-ui';
-import { trimStart } from 'lodash';
-import { useHistory } from 'react-router-dom';
 
 import { generateAccount } from './accounts/account-generator';
 import { getSoapFetch } from './network/fetch';
@@ -86,46 +84,6 @@ export const ACTION_TYPES: typeof shell.ACTION_TYPES = {
 	NEW: 'new',
 	ACCOUNT_MENU: 'account_menu'
 };
-
-function parsePath(path: string): string {
-	return `/${trimStart(path, '/')}`;
-}
-function usePushHistoryMock(): (params: shell.HistoryParams) => void {
-	const history = useHistory();
-
-	return useCallback(
-		(location: string | shell.HistoryParams) => {
-			if (typeof location === 'string') {
-				history.push(parsePath(location));
-			} else if (typeof location.path === 'string') {
-				history.push(parsePath(location.path));
-			} else {
-				history.push(location.path);
-			}
-		},
-		[history]
-	);
-}
-
-function useReplaceHistoryMock(): (params: shell.HistoryParams) => void {
-	const history = useHistory();
-
-	return useCallback(
-		(location: string | shell.HistoryParams) => {
-			if (typeof location === 'string') {
-				history.replace(parsePath(location));
-			} else if (typeof location.path === 'string') {
-				history.replace(parsePath(location.path));
-			} else {
-				history.replace(location.path);
-			}
-		},
-		[history]
-	);
-}
-
-export const usePushHistoryCallback = usePushHistoryMock;
-export const useReplaceHistoryCallback = useReplaceHistoryMock;
 
 /*
  * Integration mocks

--- a/test/mocks/routing/use-history-navigation-mock.ts
+++ b/test/mocks/routing/use-history-navigation-mock.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { HistoryNavigation } from '../../../helpers/use-history-navigation';
+import * as historyNavigation from '../../../helpers/use-history-navigation';
+
+/**
+ * Generates a mock for useHistoryNavigation hook and returns the result of the
+ * hook, filled with mocked functions
+ */
+export const mockUseHistoryNavigation = (): HistoryNavigation => {
+	const result = {
+		replaceHistory: jest.fn(),
+		pushHistory: jest.fn()
+	} satisfies HistoryNavigation;
+	jest.spyOn(historyNavigation, 'useHistoryNavigation').mockReturnValue(result);
+
+	return result;
+};

--- a/test/test-setup.tsx
+++ b/test/test-setup.tsx
@@ -105,7 +105,7 @@ export const ProvidersWrapper = ({
 	children,
 	store,
 	initialEntries = ['/'],
-	path = '/'
+	path = '/*'
 }: PropsWithChildren<ProvidersWrapperProps>): React.JSX.Element => {
 	const i18n = useMemo(() => getAppI18n(), []);
 

--- a/test/test-setup.tsx
+++ b/test/test-setup.tsx
@@ -25,7 +25,7 @@ import userEvent, { UserEvent as RTLUserEvent } from '@testing-library/user-even
 import { ModalManager, SnackbarManager, ThemeProvider } from '@zextras/carbonio-design-system';
 import { I18nextProvider } from 'react-i18next';
 import { Provider } from 'react-redux';
-import { MemoryRouter, MemoryRouterProps, Route, RouteProps } from 'react-router-dom';
+import { MemoryRouter, MemoryRouterProps, Route, RouteProps, Routes } from 'react-router-dom';
 import { Store } from 'redux';
 
 import { getAppI18n } from './i18n/i18n-test-factory';
@@ -112,20 +112,26 @@ export const ProvidersWrapper = ({
 	return (
 		<ThemeProvider>
 			<MemoryRouter
+				future={{ v7_startTransition: false, v7_relativeSplatPath: false }}
 				initialEntries={initialEntries}
 				initialIndex={(initialEntries?.length || 1) - 1}
 			>
-				<Route path={path}>
-					<StoreProvider store={store}>
-						<I18nextProvider i18n={i18n}>
-							<SnackbarManager>
-								<PreviewsManagerContext.Provider value={previewContextMock}>
-									<ModalManager>{children}</ModalManager>
-								</PreviewsManagerContext.Provider>
-							</SnackbarManager>
-						</I18nextProvider>
-					</StoreProvider>
-				</Route>
+				<Routes>
+					<Route
+						path={path}
+						element={
+							<StoreProvider store={store}>
+								<I18nextProvider i18n={i18n}>
+									<SnackbarManager>
+										<PreviewsManagerContext.Provider value={previewContextMock}>
+											<ModalManager>{children}</ModalManager>
+										</PreviewsManagerContext.Provider>
+									</SnackbarManager>
+								</I18nextProvider>
+							</StoreProvider>
+						}
+					/>
+				</Routes>
 			</MemoryRouter>
 		</ThemeProvider>
 	);


### PR DESCRIPTION
- Update the test setup utilities to work with react-router-dom v6
- Add an utility hook to return shortcut functions to replace or push into history navigation

Refs: CO-1779