### PR TITLE
fix: import getFolderIconColor from carbonio-ui-commons

### DIFF
--- a/components/select/folders/flat-folder.tsx
+++ b/components/select/folders/flat-folder.tsx
@@ -9,8 +9,7 @@ import React, { useCallback } from 'react';
 import { Container, Row, Icon } from '@zextras/carbonio-design-system';
 import { noop } from 'lodash';
 
-import { getFolderIconName, getSystemFolderTranslatedName } from './utils';
-import { getFolderIconColor } from '../../../../commons/utilities';
+import { getFolderIconColor, getFolderIconName, getSystemFolderTranslatedName } from './utils';
 import { isRoot } from '../../../helpers/folders';
 import { Folder } from '../../../types';
 import { StaticBreadcrumbs } from '../../breadcrumbs/static-breadcrumbs';


### PR DESCRIPTION
- the import was from the module that uses carbonio-ui-commons.
- since carbonio-ui-commons does not build standalone this error cannot be caught by the CI but only when used in another module (i.e.: work in contacts but not in mails)
- **checked works in mails, calendars and contacts**