### PR TITLE
fix(search.ts): handle empty string for chip label and value

### DIFF
--- a/src/helpers/search.ts
+++ b/src/helpers/search.ts
@@ -17,11 +17,11 @@ const WHOLE_QUERY_REGEX = new RegExp(
 );
 
 function getChipString(chip: ConvertSearchChipToStringProps): string {
-	if (typeof chip.value === 'string') {
+	if (typeof chip.value === 'string' && chip.value !== '') {
 		return chip.value;
 	}
 
-	if (typeof chip.label === 'string') {
+	if (typeof chip.label === 'string' && chip.label !== '') {
 		return chip.label;
 	}
 

--- a/src/helpers/tests/search.test.ts
+++ b/src/helpers/tests/search.test.ts
@@ -23,6 +23,31 @@ describe('search', () => {
 			expect(result).toBe(label);
 		});
 
+		it("should return value of the 'label' field if it is set and 'value' is empty string", () => {
+			const label = faker.word.noun();
+			const chip = { label, value: '' };
+			const result = convertSearchChipToString(chip);
+			expect(result).toBe(label);
+		});
+
+		it("should return empty string if both 'value' and 'label' are empty string", () => {
+			const chip = { label: '', value: '' };
+			const result = convertSearchChipToString(chip);
+			expect(result).toBe('');
+		});
+
+		it("should return empty string if 'value' is undefined and 'label' is empty string", () => {
+			const chip = { label: '', value: undefined };
+			const result = convertSearchChipToString(chip);
+			expect(result).toBe('');
+		});
+
+		it("should return empty string if 'label' is undefined and 'value' is empty string", () => {
+			const chip = { label: undefined, value: '' };
+			const result = convertSearchChipToString(chip);
+			expect(result).toBe('');
+		});
+
 		it("should return value of the 'value' field if it is set", () => {
 			const value = faker.word.noun();
 			const label = faker.word.noun();


### PR DESCRIPTION
Update getChipString to return an empty string when both 'label' and 'value' are empty strings or undefined. Add tests to cover cases where 'label' or 'value' are empty strings or undefined in search.test.ts.