### PR TITLE
build: use inline sources

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>zextras/infra-renovate-config",
-    "github>zextras/infra-renovate-config:javascript"
-  ]
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": [
+		"github>zextras/infra-renovate-config",
+		"github>zextras/infra-renovate-config:javascript"
+	]
 }

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -13,6 +13,7 @@
 		"jsx": "react",
 		"declaration": true,
 		"sourceMap": true,
+		"inlineSources": true,
 		"declarationMap": false,
 		"outDir": "lib",
 		"rootDir": "src"


### PR DESCRIPTION
The project needs to be built as ES module, else import.meta.url is not allowed in CommonJS output.
However moduleResolution is "Bundler" so it expects a bundler to take care of linking sources, thus currently we have lots of warning when running tests ("sourcemap not found").

Unfortunately if we want to use workers with import.meta.url there is not other way other than compiling as ESNext or any ES module.

What does not work (module, moduleResolution):

- Node16, Node16 -> needs package.json to have type "module" (else defaults to CommonJS) + needs explicit file extension
- EsNext, NodeNext and other variants because they requires explicit extension
- NodeNext, NodeNext -> CommonJS incompatible with import.meta.url.

In the end using bundler is still ok because this library is used in projects bundled with webpack and workers start properly