### PR TITLE
feat(CO-2786): add ARCHIVE action and update FOLDERS constant

### DIFF
--- a/src/constants/folders.ts
+++ b/src/constants/folders.ts
@@ -14,7 +14,8 @@ export const FolderActionsType = {
 	REMOVE_FROM_LIST: 'removeFromList',
 	SHARES_INFO: 'sharesInfo',
 	SHARE: 'share',
-	MARK_ALL_READ: 'read'
+	MARK_ALL_READ: 'read',
+	ARCHIVE: 'archive'
 } as const;
 
 export const FOLDERS = {
@@ -34,5 +35,6 @@ export const FOLDERS = {
 	IM_LOGS: '14',
 	TASKS: '15',
 	BRIEFCASE: '16',
-	LAST_SYSTEM_FOLDER_POSITION: '16.1'
+	ARCHIVE: '17',
+	LAST_SYSTEM_FOLDER_POSITION: '17.1'
 } as const;


### PR DESCRIPTION
This PR adds support for an ARCHIVE folder by introducing a new folder action type and updating the folder constants. The changes include adding an ARCHIVE action to the FolderActionsType constant, adding an ARCHIVE folder with ID '17' to the FOLDERS constant, and updating LAST_SYSTEM_FOLDER_POSITION from '16.1' to '17.1' to reflect the new highest system folder.