### PR TITLE
fix(CO-3532): improve folder deletion handling to remove entire subtree

### DIFF
--- a/src/worker/handle-message.ts
+++ b/src/worker/handle-message.ts
@@ -331,17 +331,36 @@ export const handleFolderModified = (modified: Array<Partial<UserFolder>>): void
 			}
 		}
 	});
+
+const collectFolderSubtreeIds = (folderId: string): string[] => {
+	const folder = folders[folderId];
+	if (!folder) {
+		return [];
+	}
+
+	return folder.children.reduce<string[]>(
+		(acc, child) => [...acc, child.id, ...collectFolderSubtreeIds(child.id)],
+		[]
+	);
+};
+
 export const handleFolderDeleted = (deleted: string[]): void =>
 	deleted.forEach((val) => {
-		const folder = folders[val];
-		if (folder) {
-			if (folder.parent) {
-				const parent = folders[folder.parent];
-				parent.children = parent.children.filter((obj) => obj.id !== val);
+		const folderIdsToDelete = [val, ...collectFolderSubtreeIds(val)];
+
+		folderIdsToDelete.forEach((folderId) => {
+			const folder = folders[folderId];
+			if (folder) {
+				if (folder.parent) {
+					const parent = folders[folder.parent];
+					if (parent) {
+						parent.children = parent.children.filter((obj) => obj.id !== folderId);
+					}
+				}
+				delete folders[folderId];
+				delete searches[folderId];
 			}
-			delete folders[val];
-			delete searches[val];
-		}
+		});
 	});
 export const handleFolderNotify = (notify: SoapNotify): void => {
 	handleFolderCreated(notify.created?.folder ?? []);

--- a/src/worker/tests/handle-message.test.ts
+++ b/src/worker/tests/handle-message.test.ts
@@ -1415,6 +1415,58 @@ describe('folders web worker', () => {
 				expect(folders[primaryAccount.id].children).toHaveLength(0);
 			});
 
+			test('when a child folder is deleted but its parent is already missing from the store, it does not throw', () => {
+				const primaryAccount = getNormalizedPrimaryAccount();
+				const parentFolder = generateSoapCustomChild({
+					...primaryAccount,
+					view: FOLDER_VIEW.appointment
+				});
+				const childFolder = generateSoapCustomChild({
+					...parentFolder,
+					view: FOLDER_VIEW.appointment
+				});
+
+				const normalizedChildFolder = {
+					...childFolder,
+					children: [],
+					depth: 2,
+					isLink: false,
+					parent: parentFolder.id
+				};
+
+				// Intentionally do NOT put parentFolder in the tree — simulates parent already deleted
+				const tree = {
+					[primaryAccount.id]: {
+						...primaryAccount,
+						children: [] as UserFolder[]
+					},
+					[childFolder.id]: normalizedChildFolder as UserFolder
+				};
+
+				testUtils.setFolders(tree);
+				testUtils.setCurrentView(FOLDER_VIEW.appointment);
+
+				const data = {
+					op: 'notify',
+					notify: {
+						deleted: [childFolder.id]
+					}
+				};
+
+				expect(() =>
+					handleMessage({
+						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+						// @ts-ignore
+						data
+					})
+				).not.toThrow();
+
+				const folders = testUtils.getFolders();
+
+				expect(folders[childFolder.id]).toBeUndefined();
+				expect(folders[primaryAccount.id].children).toHaveLength(0);
+			});
+
 			test('when deleted ids include parent and child, deletion is order-independent', () => {
 				const primaryAccount = getNormalizedPrimaryAccount();
 				const parentFolder = generateSoapCustomChild({

--- a/src/worker/tests/handle-message.test.ts
+++ b/src/worker/tests/handle-message.test.ts
@@ -1357,6 +1357,122 @@ describe('folders web worker', () => {
 				expect(folders[folderToDelete.id]).toBeDefined();
 				expect(folders[primaryAccount.id].children).toHaveLength(1);
 			});
+
+			test('when a folder with children is deleted, the whole subtree is removed', () => {
+				const primaryAccount = getNormalizedPrimaryAccount();
+				const parentFolder = generateSoapCustomChild({
+					...primaryAccount,
+					view: FOLDER_VIEW.appointment
+				});
+				const childFolder = generateSoapCustomChild({
+					...parentFolder,
+					view: FOLDER_VIEW.appointment
+				});
+
+				const normalizedChildFolder = {
+					...childFolder,
+					children: [],
+					depth: 2,
+					isLink: false,
+					parent: parentFolder.id
+				};
+				const normalizedParentFolder = {
+					...parentFolder,
+					children: [normalizedChildFolder],
+					depth: 1,
+					isLink: false,
+					parent: primaryAccount.id
+				};
+				const tree = {
+					[primaryAccount.id]: {
+						...primaryAccount,
+						children: [normalizedParentFolder] as UserFolder[]
+					},
+					[parentFolder.id]: normalizedParentFolder as UserFolder,
+					[childFolder.id]: normalizedChildFolder as UserFolder
+				};
+
+				testUtils.setFolders(tree);
+				testUtils.setCurrentView(FOLDER_VIEW.appointment);
+
+				const data = {
+					op: 'notify',
+					notify: {
+						deleted: [parentFolder.id]
+					}
+				};
+
+				handleMessage({
+					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+					// @ts-ignore
+					data
+				});
+
+				const folders = testUtils.getFolders();
+
+				expect(folders[parentFolder.id]).toBeUndefined();
+				expect(folders[childFolder.id]).toBeUndefined();
+				expect(folders[primaryAccount.id].children).toHaveLength(0);
+			});
+
+			test('when deleted ids include parent and child, deletion is order-independent', () => {
+				const primaryAccount = getNormalizedPrimaryAccount();
+				const parentFolder = generateSoapCustomChild({
+					...primaryAccount,
+					view: FOLDER_VIEW.appointment
+				});
+				const childFolder = generateSoapCustomChild({
+					...parentFolder,
+					view: FOLDER_VIEW.appointment
+				});
+
+				const normalizedChildFolder = {
+					...childFolder,
+					children: [],
+					depth: 2,
+					isLink: false,
+					parent: parentFolder.id
+				};
+				const normalizedParentFolder = {
+					...parentFolder,
+					children: [normalizedChildFolder],
+					depth: 1,
+					isLink: false,
+					parent: primaryAccount.id
+				};
+				const tree = {
+					[primaryAccount.id]: {
+						...primaryAccount,
+						children: [normalizedParentFolder] as UserFolder[]
+					},
+					[parentFolder.id]: normalizedParentFolder as UserFolder,
+					[childFolder.id]: normalizedChildFolder as UserFolder
+				};
+
+				testUtils.setFolders(tree);
+				testUtils.setCurrentView(FOLDER_VIEW.appointment);
+
+				const data = {
+					op: 'notify',
+					notify: {
+						deleted: [parentFolder.id, childFolder.id]
+					}
+				};
+
+				expect(() =>
+					handleMessage({
+						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+						// @ts-ignore
+						data
+					})
+				).not.toThrow();
+
+				const folders = testUtils.getFolders();
+
+				expect(folders[parentFolder.id]).toBeUndefined();
+				expect(folders[childFolder.id]).toBeUndefined();
+				expect(folders[primaryAccount.id].children).toHaveLength(0);
+			});
 		});
 	});
 });


### PR DESCRIPTION
Proper handling of deletion of folder with children.
- checks whether parent exists before touching parent.children (prevents the Cannot read properties of undefined (reading 'children') error).
- Recursively collects and deletes the full folder subtree (parent + descendants) from both folders and searches.
- Handles deletion notifications that include both parent and child IDs without throwing.