### PR TITLE
chore(deps): update dependency zextras/jenkins-lib-common to v4.2.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 library(
-    identifier: 'jenkins-lib-common@feat/make-package-stage-optional',
+    identifier: 'jenkins-lib-common@v4.2.0',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',


### PR DESCRIPTION
Replaces the unmerged-branch pin `jenkins-lib-common@feat/make-package-stage-optional` with a real
release tag: `jenkins-lib-common@v4.2.0`.

`carbonio-ui-commons` was the only repo in the org pinning a branch instead of a tag, because it needed
an optional Package stage that had never been released — the `feat/make-package-stage-optional` branch
was never merged. `hasPackage` landed in `v4.2.0` via zextras/jenkins-lib-common#156, so the capability
this repo depended on now exists in a tagged release.

The existing `uiPipeline(hasPackage: false)` call site is left untouched: `hasPackage` is the literal
parameter name in v4.2.0's `uiPipeline` (`Boolean hasPackage = args.get('hasPackage', true)`), so the
call keeps working as-is.

`hasPackage: false` must stay set because this repo builds via `tsc` into `lib/` and publishes with
`pnpm pack` — it produces no `dist/yap.json`, which is exactly what the Package stage (yap/deb/rpm build
+ upload) requires. Running that stage here would fail immediately.

v4.2.0 also carries the `gitleaksStage` fix (zextras/jenkins-lib-common#157) that appends
`gitleaks-report.json` to `.git/info/exclude`, though this repo's Package stage being skipped means it
was not directly affected by the REUSE-lint failure mode.

Ref: https://zextras.atlassian.net/browse/IN-1168
